### PR TITLE
Add onboarding flow and Homebrew release scaffolding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release (e.g. v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build_release:
+    name: Build Release Artifacts
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      sha256: ${{ steps.meta.outputs.sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Compute artifact metadata
+        id: meta
+        run: |
+          version="$(python - <<'PY'
+          import pathlib, tomllib
+          pyproject = pathlib.Path("pyproject.toml")
+          print(tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"])
+          PY
+          )"
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          sha256="$(sha256sum "dist/matteros-${version}.tar.gz" | awk '{print $1}')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+          generate_release_notes: true
+
+  update_homebrew_tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs: build_release
+    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN != '' }}
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Update tap formula
+        env:
+          TAP_REPO: danielalkurdi/homebrew-matteros
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          VERSION: ${{ needs.build_release.outputs.version }}
+          TAG: ${{ needs.build_release.outputs.tag }}
+          SHA256: ${{ needs.build_release.outputs.sha256 }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" tap
+          mkdir -p tap/Formula
+
+          sed \
+            -e "s/__VERSION__/${VERSION}/g" \
+            -e "s/__TAG__/${TAG}/g" \
+            -e "s/__SHA256__/${SHA256}/g" \
+            packaging/homebrew/matteros.rb.tmpl > tap/Formula/matteros.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/matteros.rb
+          git commit -m "matteros ${TAG}" || echo "No formula changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ MVP focus:
 - Human approval before side effects
 - Immutable audit log for defensibility
 
+## Install (Homebrew first)
+
+```bash
+brew tap danielalkurdi/matteros
+brew install matteros
+```
+
+Python fallback:
+
+```bash
+pipx install git+https://github.com/danielalkurdi/matteros.git
+```
+
+See [docs/INSTALL.md](./docs/INSTALL.md) for additional installation notes.
+
 ## Quick start
 
 ```bash
@@ -16,12 +31,33 @@ source .venv/bin/activate
 pip install -e .[dev]
 
 matteros init
+matteros onboard
 matteros auth login --client-id <your-app-client-id>
 matteros llm doctor
 matteros connectors list
 matteros playbooks list
 matteros run matteros/playbooks/daily_time_capture.yml --dry-run --input tests/fixtures/run_input.json
 matteros audit verify --run-id <RUN_ID> --source both
+```
+
+## Onboarding
+
+Guided setup:
+
+```bash
+matteros onboard
+```
+
+Non-interactive setup for CI/devcontainers:
+
+```bash
+matteros onboard --non-interactive --yes --skip-auth
+```
+
+Readiness status:
+
+```bash
+matteros onboard status
 ```
 
 ## Audit verification

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,27 @@
+# Installation
+
+## Homebrew (primary)
+
+```bash
+brew tap danielalkurdi/matteros
+brew install matteros
+```
+
+## Python fallback (pipx)
+
+```bash
+pipx install git+https://github.com/danielalkurdi/matteros.git
+```
+
+## First-run onboarding
+
+```bash
+matteros onboard
+matteros onboard status
+```
+
+## Non-interactive onboarding
+
+```bash
+matteros onboard --non-interactive --yes --skip-auth
+```

--- a/matteros/core/config.py
+++ b/matteros/core/config.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConfigError(RuntimeError):
+    """Raised when MatterOS config cannot be parsed or saved."""
+
+
+CURRENT_CONFIG_VERSION = 1
+
+
+class ProfileConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = "default"
+
+
+class PathsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_path: str
+    default_playbook: str
+    fixtures_root: str | None = None
+
+
+class LLMConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = "local"
+    remote_enabled: bool = False
+    model_allowlist: list[str] = Field(default_factory=list)
+
+
+class MSGraphConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_id: str = "common"
+    scopes: str = "offline_access User.Read Mail.Read Calendars.Read"
+    auth_pending: bool = True
+
+
+class OnboardingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = CURRENT_CONFIG_VERSION
+    completed_at: str | None = None
+    last_smoke_test_status: str | None = None
+    last_smoke_test_run_id: str | None = None
+
+
+class MatterOSConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    config_version: int = CURRENT_CONFIG_VERSION
+    log_level: str = "info"
+    profile: ProfileConfig
+    paths: PathsConfig
+    llm: LLMConfig = Field(default_factory=LLMConfig)
+    ms_graph: MSGraphConfig = Field(default_factory=MSGraphConfig)
+    onboarding: OnboardingConfig = Field(default_factory=OnboardingConfig)
+
+
+class LoadedConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    config: MatterOSConfig
+    existed: bool
+    migrated: bool = False
+    raw_legacy_payload: dict[str, Any] | None = None
+
+
+def default_config(*, home: Path, profile: str = "default") -> MatterOSConfig:
+    workspace = Path.cwd().resolve()
+    default_playbook = (home / "playbooks" / "daily_time_capture.yml").resolve()
+    fixtures_root = (home / "fixtures" / "ms_graph").resolve()
+
+    return MatterOSConfig(
+        profile=ProfileConfig(name=profile),
+        paths=PathsConfig(
+            workspace_path=str(workspace),
+            default_playbook=str(default_playbook),
+            fixtures_root=str(fixtures_root),
+        ),
+    )
+
+
+def load_config(*, path: Path, home: Path) -> LoadedConfig:
+    if not path.exists():
+        return LoadedConfig(config=default_config(home=home), existed=False)
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"invalid config yaml at {path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ConfigError("config root must be a mapping")
+
+    # New structured config.
+    if "config_version" in raw:
+        try:
+            parsed = MatterOSConfig.model_validate(raw)
+        except Exception as exc:
+            raise ConfigError(f"invalid config schema: {exc}") from exc
+        return LoadedConfig(config=_normalize_config_paths(parsed), existed=True)
+
+    # Legacy flat config migration.
+    migrated_payload = _migrate_legacy_payload(raw, home=home)
+    try:
+        parsed = MatterOSConfig.model_validate(migrated_payload)
+    except Exception as exc:
+        raise ConfigError(f"failed to migrate legacy config: {exc}") from exc
+
+    return LoadedConfig(
+        config=_normalize_config_paths(parsed),
+        existed=True,
+        migrated=True,
+        raw_legacy_payload=raw,
+    )
+
+
+def save_config_atomic(*, config: MatterOSConfig, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+
+    payload = config.model_dump(mode="json")
+    content = yaml.safe_dump(payload, sort_keys=False)
+
+    tmp_path.write_text(content, encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def backup_legacy_config(*, config_path: Path) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    backup_path = config_path.with_name(f"{config_path.name}.bak.{timestamp}")
+    backup_path.write_text(config_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return backup_path
+
+
+def _normalize_config_paths(config: MatterOSConfig) -> MatterOSConfig:
+    normalized = config.model_copy(deep=True)
+
+    normalized.paths.workspace_path = str(Path(normalized.paths.workspace_path).expanduser().resolve())
+    normalized.paths.default_playbook = str(Path(normalized.paths.default_playbook).expanduser().resolve())
+    if normalized.paths.fixtures_root:
+        normalized.paths.fixtures_root = str(Path(normalized.paths.fixtures_root).expanduser().resolve())
+
+    return normalized
+
+
+def _migrate_legacy_payload(payload: dict[str, Any], *, home: Path) -> dict[str, Any]:
+    model_provider = str(payload.get("model_provider", "local"))
+    log_level = str(payload.get("log_level", "info"))
+    tenant_id = str(payload.get("ms_graph_tenant_id", "common"))
+    scopes = str(payload.get("ms_graph_scopes", "offline_access User.Read Mail.Read Calendars.Read"))
+
+    remote_enabled = model_provider in {"openai", "anthropic"}
+
+    migrated = default_config(home=home).model_dump(mode="json")
+    migrated["log_level"] = log_level
+    migrated["llm"]["provider"] = model_provider
+    migrated["llm"]["remote_enabled"] = remote_enabled
+    migrated["ms_graph"]["tenant_id"] = tenant_id
+    migrated["ms_graph"]["scopes"] = scopes
+
+    return migrated
+
+
+def config_json(config: MatterOSConfig) -> str:
+    return json.dumps(config.model_dump(mode="json"), sort_keys=True)

--- a/matteros/core/onboarding.py
+++ b/matteros/core/onboarding.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from matteros.core.audit import AuditLogger, VerificationResult
+from matteros.core.playbook import PlaybookError, load_playbook
+from matteros.core.runner import RunnerOptions, WorkflowRunner
+from matteros.core.types import RunSummary
+
+
+@dataclass(slots=True)
+class OnboardingStatus:
+    config_present: bool
+    auth_ready: bool
+    llm_ready: bool
+    playbook_ready: bool
+    smoke_test_passed: bool
+    details: dict[str, Any]
+
+
+def ensure_home_scaffold(*, home: Path) -> dict[str, Path]:
+    home.mkdir(parents=True, exist_ok=True)
+    audit_dir = home / "audit"
+    auth_dir = home / "auth"
+    playbooks_dir = home / "playbooks"
+    fixtures_dir = home / "fixtures" / "ms_graph"
+    exports_dir = home / "exports"
+
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    fixtures_dir.mkdir(parents=True, exist_ok=True)
+    exports_dir.mkdir(parents=True, exist_ok=True)
+
+    sample_playbook_path = playbooks_dir / "daily_time_capture.yml"
+    if not sample_playbook_path.exists():
+        sample = (Path(__file__).resolve().parents[1] / "playbooks" / "daily_time_capture.yml").read_text(
+            encoding="utf-8"
+        )
+        sample_playbook_path.write_text(sample, encoding="utf-8")
+
+    _ensure_fixture_files(fixtures_dir)
+
+    return {
+        "home": home,
+        "audit_dir": audit_dir,
+        "auth_dir": auth_dir,
+        "playbooks_dir": playbooks_dir,
+        "fixtures_dir": fixtures_dir,
+        "exports_dir": exports_dir,
+        "sample_playbook": sample_playbook_path,
+    }
+
+
+def smoke_test_dry_run(
+    *,
+    runner: WorkflowRunner,
+    audit: AuditLogger,
+    playbook_path: Path,
+    workspace_path: Path,
+    fixtures_root: Path,
+    output_csv_path: Path,
+    reviewer: str,
+) -> tuple[RunSummary | None, VerificationResult | None, str | None]:
+    try:
+        playbook = load_playbook(playbook_path)
+    except PlaybookError as exc:
+        return None, None, str(exc)
+
+    try:
+        summary = runner.run(
+            playbook=playbook,
+            inputs={
+                "date": "2026-02-20",
+                "workspace_path": str(workspace_path),
+                "fixtures_root": str(fixtures_root),
+                "output_csv_path": str(output_csv_path),
+                "matter_hint": "",
+            },
+            options=RunnerOptions(
+                dry_run=True,
+                approve_mode=False,
+                reviewer=reviewer,
+            ),
+        )
+    except Exception as exc:
+        return None, None, str(exc)
+
+    verify = audit.verify_run(run_id=summary.run_id, source="both")
+    if not verify.ok:
+        return summary, verify, f"audit verification failed: {verify.reason}"
+
+    return summary, verify, None
+
+
+def build_onboarding_status(
+    *,
+    config_present: bool,
+    auth_ready: bool,
+    llm_ready: bool,
+    playbook_path: Path,
+    smoke_status: str | None,
+    smoke_run_id: str | None,
+) -> OnboardingStatus:
+    playbook_ready = playbook_path.exists()
+    smoke_test_passed = smoke_status == "passed"
+
+    details = {
+        "playbook_path": str(playbook_path),
+        "smoke_status": smoke_status,
+        "smoke_run_id": smoke_run_id,
+    }
+
+    return OnboardingStatus(
+        config_present=config_present,
+        auth_ready=auth_ready,
+        llm_ready=llm_ready,
+        playbook_ready=playbook_ready,
+        smoke_test_passed=smoke_test_passed,
+        details=details,
+    )
+
+
+def _ensure_fixture_files(fixtures_dir: Path) -> None:
+    calendar_path = fixtures_dir / "calendar_events.json"
+    if not calendar_path.exists():
+        calendar_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "onboard-cal-1",
+                        "subject": "MAT-123 Onboarding call",
+                        "start": {"dateTime": "2026-02-20T09:00:00Z"},
+                        "end": {"dateTime": "2026-02-20T09:45:00Z"},
+                    }
+                ],
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    sent_path = fixtures_dir / "sent_emails.json"
+    if not sent_path.exists():
+        sent_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "onboard-mail-1",
+                        "subject": "Re: MAT-123 onboarding summary",
+                        "sentDateTime": "2026-02-20T10:15:00Z",
+                    }
+                ],
+                indent=2,
+            ),
+            encoding="utf-8",
+        )

--- a/matteros/llm/adapter.py
+++ b/matteros/llm/adapter.py
@@ -18,6 +18,8 @@ class LLMAdapter:
         self,
         default_provider: str | None = None,
         *,
+        allow_remote_models: bool | None = None,
+        model_allowlist: Sequence[str] | None = None,
         max_retries: int | None = None,
         retry_backoff_seconds: float | None = None,
     ):
@@ -33,8 +35,16 @@ class LLMAdapter:
             if retry_backoff_seconds is not None
             else float(os.getenv("MATTEROS_LLM_RETRY_BACKOFF_SECONDS", "0.5"))
         )
-        self.allow_remote_models = _truthy(os.getenv("MATTEROS_ALLOW_REMOTE_MODELS", "false"))
-        self.model_allowlist = _split_csv(os.getenv("MATTEROS_LLM_MODEL_ALLOWLIST"))
+        self.allow_remote_models = (
+            allow_remote_models
+            if allow_remote_models is not None
+            else _truthy(os.getenv("MATTEROS_ALLOW_REMOTE_MODELS", "false"))
+        )
+        self.model_allowlist = (
+            list(model_allowlist)
+            if model_allowlist is not None
+            else list(_split_csv(os.getenv("MATTEROS_LLM_MODEL_ALLOWLIST")))
+        )
 
     def run(
         self,

--- a/packaging/homebrew/matteros.rb.tmpl
+++ b/packaging/homebrew/matteros.rb.tmpl
@@ -1,0 +1,21 @@
+class Matteros < Formula
+  include Language::Python::Virtualenv
+
+  desc "CLI-first legal ops orchestration with safe, auditable workflows"
+  homepage "https://github.com/danielalkurdi/matteros"
+  url "https://github.com/danielalkurdi/matteros/releases/download/__TAG__/matteros-__VERSION__.tar.gz"
+  sha256 "__SHA256__"
+  license "AGPL-3.0-only"
+
+  depends_on "python@3.12"
+
+  def install
+    virtualenv_create(libexec, "python3.12")
+    system libexec/"bin/pip", "install", buildpath
+    bin.install_symlink libexec/"bin/matteros"
+  end
+
+  test do
+    assert_match "MatterOS", shell_output("#{bin}/matteros --help")
+  end
+end

--- a/tests/test_cli_onboard.py
+++ b/tests/test_cli_onboard.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from matteros.cli import app
+from matteros.core.config import load_config
+
+runner = CliRunner()
+
+
+def test_onboard_non_interactive_creates_config_and_smoke_run(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--non-interactive",
+            "--yes",
+            "--skip-auth",
+            "--home",
+            str(home),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "onboarding complete" in result.stdout
+
+    loaded = load_config(path=home / "config.yml", home=home)
+    cfg = loaded.config
+    assert loaded.existed
+    assert cfg.onboarding.completed_at is not None
+    assert cfg.onboarding.last_smoke_test_status == "passed"
+    assert cfg.onboarding.last_smoke_test_run_id is not None
+
+
+def test_onboard_status_shows_pending_auth_when_skipped(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+
+    setup = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--non-interactive",
+            "--yes",
+            "--skip-auth",
+            "--skip-smoke-test",
+            "--home",
+            str(home),
+        ],
+    )
+    assert setup.exit_code == 0
+
+    result = runner.invoke(app, ["onboard", "status", "--home", str(home)])
+    assert result.exit_code == 1
+    assert "auth_ready: False" in result.stdout
+
+
+def test_onboard_status_passes_with_valid_auth_and_smoke(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+
+    setup = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--non-interactive",
+            "--yes",
+            "--skip-auth",
+            "--home",
+            str(home),
+        ],
+    )
+    assert setup.exit_code == 0
+
+    # Simulate valid token cache and clear auth_pending flag.
+    token_path = home / "auth" / "ms_graph_token.json"
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "token",
+                "refresh_token": "refresh",
+                "expires_at": 32503680000,
+                "tenant_id": "common",
+                "client_id": "test-client",
+                "scope": "offline_access User.Read Mail.Read Calendars.Read",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_config(path=home / "config.yml", home=home)
+    cfg = loaded.config
+    cfg.ms_graph.auth_pending = False
+    from matteros.core.config import save_config_atomic
+
+    save_config_atomic(config=cfg, path=home / "config.yml")
+
+    result = runner.invoke(app, ["onboard", "status", "--home", str(home)])
+    assert result.exit_code == 0
+    assert "auth_ready: True" in result.stdout
+    assert "smoke_test_passed: True" in result.stdout

--- a/tests/test_onboarding_config_migration.py
+++ b/tests/test_onboarding_config_migration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from matteros.cli import app
+from matteros.core.config import load_config
+
+runner = CliRunner()
+
+
+def test_onboard_migrates_legacy_config_and_creates_backup(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+
+    legacy = home / "config.yml"
+    legacy.write_text(
+        """
+model_provider: openai
+log_level: debug
+ms_graph_tenant_id: my-tenant
+ms_graph_scopes: offline_access User.Read
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--non-interactive",
+            "--yes",
+            "--skip-auth",
+            "--skip-smoke-test",
+            "--home",
+            str(home),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "migrated legacy config" in result.stdout
+
+    backups = sorted(home.glob("config.yml.bak.*"))
+    assert backups, "expected legacy config backup file"
+
+    loaded = load_config(path=home / "config.yml", home=home)
+    cfg = loaded.config
+    assert cfg.llm.provider == "openai"
+    assert cfg.log_level == "debug"
+    assert cfg.ms_graph.tenant_id == "my-tenant"
+    assert cfg.ms_graph.scopes == "offline_access User.Read"


### PR DESCRIPTION
## Summary
- add structured config schema with legacy migration + atomic saves
- add guided onboarding command (`matteros onboard`) and readiness check (`matteros onboard status`)
- scaffold Homebrew release automation workflow and formula template
- add onboarding CLI/migration tests and update install docs

## Validation
- `pytest -q`
- CLI smoke: `matteros onboard --non-interactive --yes --skip-auth`

## Notes
- release workflow updates Homebrew tap only when `HOMEBREW_TAP_GITHUB_TOKEN` is configured