### PR TITLE
Refresh docs tone and update current capability coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,206 @@
 # MatterOS
 
-MatterOS is an open-source, self-hostable legal ops orchestration CLI.
+MatterOS is an open-source, self-hosted legal ops command center.
 
-MVP focus:
-- Activity-to-Time workflow for non-billable admin reduction
-- Microsoft-first connectors (Outlook sent mail + Calendar) plus filesystem metadata
-- Human approval before side effects
-- Immutable audit log for defensibility
+It is less "chat with a black box" and more "run explicit workflows with approvals, logs, and receipts."
 
-## Install (Homebrew first)
+## Why it exists
+
+Legal work is fragmented across inboxes, calendars, documents, and matter systems. MatterOS focuses on the unglamorous but expensive part of the day:
+
+- turning scattered activity into structured suggestions
+- reviewing and approving side effects before they happen
+- keeping an auditable record of what changed, when, and why
+
+## What MatterOS can do today
+
+- Playbook-driven workflow execution (`collect`, `transform`, `llm`, `approve`, `apply`)
+- Dry-run planning with zero external writes
+- Approval-gated apply steps for side effects
+- Hash-chained audit logs in SQLite + JSONL with verification CLI
+- Microsoft Graph calendar/mail, filesystem, CSV export connectors
+- Optional Slack, Jira, GitHub, iCal connectors
+- Local plugin connector discovery from `~/.matteros/plugins` or `<home>/plugins`
+- Proactive drafts queue + review, learning, and digest commands
+- Background daemon scheduler + activity watcher
+- TUI dashboard + Web dashboard
+- Team user/reporting primitives
+
+## Install
+
+### Homebrew
 
 ```bash
 brew tap danielalkurdi/matteros
 brew install matteros
 ```
 
-Python fallback:
+### Source install (recommended for full feature set)
+
+```bash
+git clone https://github.com/danielalkurdi/matteros.git
+cd matteros
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[all,dev]'
+```
+
+### Python fallback (CLI-focused)
 
 ```bash
 pipx install git+https://github.com/danielalkurdi/matteros.git
 ```
 
-See [docs/INSTALL.md](./docs/INSTALL.md) for additional installation notes.
+More install options: [docs/INSTALL.md](./docs/INSTALL.md)
 
-## Quick start
+## Quick start (5 minutes)
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .[dev]
-
 matteros init
-matteros onboard
-matteros auth login --client-id <your-app-client-id>
-matteros llm doctor
+matteros onboard --non-interactive --yes --skip-auth
 matteros connectors list
 matteros playbooks list
-matteros run matteros/playbooks/daily_time_capture.yml --dry-run --input tests/fixtures/run_input.json
+
+matteros run playbooks/daily_time_capture.yml \
+  --dry-run \
+  --input tests/fixtures/run_input.json
+
+matteros audit show --last 20
 matteros audit verify --run-id <RUN_ID> --source both
 ```
 
-## Onboarding
+## Typical daily flow
 
-Guided setup:
-
-```bash
-matteros onboard
-```
-
-Non-interactive setup for CI/devcontainers:
+Generate suggestions:
 
 ```bash
-matteros onboard --non-interactive --yes --skip-auth
+matteros run playbooks/daily_time_capture.yml \
+  --dry-run \
+  --input tests/fixtures/run_input.json
 ```
 
-Readiness status:
+Review drafts interactively:
 
 ```bash
-matteros onboard status
+matteros review --limit 20
 ```
 
-## Audit verification
+Learn from feedback history:
 
 ```bash
-matteros audit verify --run-id <RUN_ID> --source both
-matteros audit verify --run-id <RUN_ID> --source db
+matteros learn --all
 ```
 
-- Success output starts with `audit verified:` and exits with code `0`.
-- Verification failure output starts with `audit verification failed:` and exits with code `1`.
-- Missing run events or invalid verify options exit with code `2`.
+Get a weekly digest:
 
-## Safety defaults
+```bash
+matteros digest --period week
+```
 
-- Connectors are read-only by default.
-- Side effects are allowed only in `apply` steps with explicit approval mode.
-- Audit events are append-only and hash-chained.
-- Audit chain integrity can be verified from SQLite and JSONL with `matteros audit verify`.
-- Microsoft Graph access uses OAuth device-code login with cached refreshable tokens in `.matteros/auth/ms_graph_token.json`.
-- LLM outputs are validated against versioned schema contracts (currently `time_entry_suggestions.v1`).
-- Remote LLM providers are opt-in via `MATTEROS_ALLOW_REMOTE_MODELS=true` (default is local-only).
+## Interfaces
 
-## LLM provider configuration
+### CLI
 
-- `MATTEROS_MODEL_PROVIDER`:
-  `local` (default), `openai`, `anthropic`
-- `MATTEROS_ALLOW_REMOTE_MODELS`:
-  must be `true` to allow `openai`/`anthropic`
-- `MATTEROS_LLM_MODEL_ALLOWLIST`:
-  optional comma-separated exact model names
-- `MATTEROS_LLM_MAX_RETRIES`:
-  retry attempts for retryable provider failures (default `2`)
-- `MATTEROS_LLM_RETRY_BACKOFF_SECONDS`:
-  exponential backoff base seconds (default `0.5`)
-- `MATTEROS_LLM_TIMEOUT_SECONDS`:
-  provider HTTP timeout in seconds (default `30`)
-- OpenAI:
-  `OPENAI_API_KEY`, optional `OPENAI_MODEL` and `OPENAI_BASE_URL`
-- Anthropic:
-  `ANTHROPIC_API_KEY`, optional `ANTHROPIC_MODEL`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_VERSION`
+```bash
+matteros --help
+```
 
-## External Provider Contract Tests (VCR)
+### TUI
 
-- Tests are skipped by default.
-- Replay existing cassettes:
-  `MATTEROS_RUN_EXTERNAL_TESTS=1 MATTEROS_VCR_RECORD_MODE=none pytest -q -m external`
-- Record/update cassettes:
-  `MATTEROS_RUN_EXTERNAL_TESTS=1 MATTEROS_VCR_RECORD_MODE=once pytest -q -m external`
-- Set provider keys before recording:
-  `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY`
+```bash
+matteros tui
+```
+
+If `textual` is missing:
+
+```bash
+pip install -e '.[tui]'
+```
+
+### Web dashboard
+
+```bash
+matteros web --open
+```
+
+On startup, MatterOS prints a bootstrap URL with a one-time access token query parameter. Open that URL first. Keep it private.
+
+If web dependencies are missing:
+
+```bash
+pip install -e '.[web]'
+```
+
+### Daemon
+
+```bash
+matteros daemon start
+matteros daemon status
+matteros daemon logs --lines 100
+```
+
+## Team mode
+
+```bash
+matteros team init --admin admin
+matteros team add-user alice --role attorney
+matteros team list-users
+matteros team report matters
+```
+
+## Safety model
+
+- Connectors declare explicit read/write operations.
+- Policy blocks undeclared or invalid operations.
+- Write side effects occur only in `apply` steps.
+- Approval flow is explicit (`--approve`) and reviewable.
+- Audit events are append-only and hash-linked.
+- `matteros audit verify` validates chain integrity.
+- Remote LLMs are opt-in; local provider is default.
+
+Deep dive docs:
+
+- [docs/policy-model.md](./docs/policy-model.md)
+- [docs/audit-schema.md](./docs/audit-schema.md)
+- [docs/threat-model.md](./docs/threat-model.md)
+- [docs/connector-specs.md](./docs/connector-specs.md)
+
+## LLM configuration
+
+Core env vars:
+
+- `MATTEROS_MODEL_PROVIDER`: `local` (default), `openai`, `anthropic`
+- `MATTEROS_ALLOW_REMOTE_MODELS`: must be `true` for remote providers
+- `MATTEROS_LLM_MODEL_ALLOWLIST`: optional comma-separated allowlist
+- `MATTEROS_LLM_MAX_RETRIES`, `MATTEROS_LLM_RETRY_BACKOFF_SECONDS`
+- `MATTEROS_LLM_TIMEOUT_SECONDS`
+
+Provider keys:
+
+- OpenAI: `OPENAI_API_KEY` (optional `OPENAI_MODEL`, `OPENAI_BASE_URL`)
+- Anthropic: `ANTHROPIC_API_KEY` (optional `ANTHROPIC_MODEL`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_VERSION`)
+
+Doctor command:
+
+```bash
+matteros llm doctor
+```
+
+## External provider contract tests (VCR)
+
+Skipped by default.
+
+Replay cassettes:
+
+```bash
+MATTEROS_RUN_EXTERNAL_TESTS=1 MATTEROS_VCR_RECORD_MODE=none pytest -q -m external
+```
+
+Record/update cassettes:
+
+```bash
+MATTEROS_RUN_EXTERNAL_TESTS=1 MATTEROS_VCR_RECORD_MODE=once pytest -q -m external
+```
 
 ## License
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,27 +1,93 @@
 # Installation
 
-## Homebrew (primary)
+This guide gives you three install paths:
+
+- fast start with Homebrew
+- full-feature source install (recommended)
+- lightweight CLI install with pipx
+
+## Option 1: Homebrew
 
 ```bash
 brew tap danielalkurdi/matteros
 brew install matteros
 ```
 
-## Python fallback (pipx)
+Then initialize:
+
+```bash
+matteros init
+matteros onboard
+```
+
+## Option 2: Source install (recommended)
+
+Use this if you want the full stack (web, tui, daemon, team, tests).
+
+```bash
+git clone https://github.com/danielalkurdi/matteros.git
+cd matteros
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[all,dev]'
+```
+
+Verify:
+
+```bash
+matteros --help
+```
+
+## Option 3: pipx fallback
 
 ```bash
 pipx install git+https://github.com/danielalkurdi/matteros.git
 ```
 
-## First-run onboarding
+This is best for baseline CLI usage. For optional interfaces, use source install or install extras in a virtualenv.
+
+## Onboarding
+
+Interactive:
 
 ```bash
 matteros onboard
 matteros onboard status
 ```
 
-## Non-interactive onboarding
+Non-interactive (CI/devcontainer):
 
 ```bash
 matteros onboard --non-interactive --yes --skip-auth
+```
+
+## Optional interfaces
+
+If a command says dependencies are missing, install the relevant extras:
+
+```bash
+pip install -e '.[web]'
+pip install -e '.[tui]'
+pip install -e '.[daemon]'
+pip install -e '.[team]'
+```
+
+Or install all at once:
+
+```bash
+pip install -e '.[all]'
+```
+
+## Web dashboard note
+
+`matteros web` prints a bootstrap URL that includes an access token query parameter.
+Open that URL first and keep it private.
+
+## Quick smoke test
+
+```bash
+matteros init
+matteros connectors list
+matteros playbooks list
+matteros run playbooks/daily_time_capture.yml --dry-run --input tests/fixtures/run_input.json
 ```

--- a/docs/connector-specs.md
+++ b/docs/connector-specs.md
@@ -1,31 +1,105 @@
-# Connector Specifications (MVP)
+# Connector Specifications
 
-## ms_graph_mail
+MatterOS connectors expose a manifest with:
 
-- Mode: read
-- Operation: `sent_emails`
-- Required params: optional `start`, `end`, or `mock_file`
-- Output: list of sent-message metadata
-- Auth: bearer token from `MATTEROS_MS_GRAPH_TOKEN` or cached OAuth token (`matteros auth login`)
+- `connector_id`
+- `default_mode` (`read` or `write`)
+- operation map (`operation -> mode`)
 
-## ms_graph_calendar
+Use this to inspect your active registry at runtime:
 
-- Mode: read
-- Operation: `events`
-- Required params: `start`, `end` or `mock_file`
-- Output: list of calendar event metadata
-- Auth: bearer token from `MATTEROS_MS_GRAPH_TOKEN` or cached OAuth token (`matteros auth login`)
+```bash
+matteros connectors list
+```
 
-## filesystem
+## Core connectors
 
-- Mode: read
-- Operation: `activity_metadata`
-- Required params: `root_path`
-- Output: list of file metadata records
+### `ms_graph_mail`
 
-## csv_export
+- Default mode: `read`
+- Operations:
+  - `sent_emails` (`read`)
+- Typical params:
+  - `start`, `end` (ISO datetimes)
+  - optional `mock_file`
+- Auth:
+  - OAuth device-code token cache (`matteros auth login`)
 
-- Mode: write
-- Operation: `export_time_entries`
-- Required params: `output_path`
-- Output: write summary (`rows_written`, `output_path`)
+### `ms_graph_calendar`
+
+- Default mode: `read`
+- Operations:
+  - `events` (`read`)
+- Typical params:
+  - `start`, `end` (ISO datetimes)
+  - optional `mock_file`
+- Auth:
+  - OAuth device-code token cache (`matteros auth login`)
+
+### `filesystem`
+
+- Default mode: `read`
+- Operations:
+  - `activity_metadata` (`read`)
+- Typical params:
+  - `root_path`
+  - optional `start`, `end`, `max_files`
+
+### `csv_export`
+
+- Default mode: `write`
+- Operations:
+  - `export_time_entries` (`write`)
+- Typical params:
+  - `output_path`
+
+## Optional built-in connectors
+
+These are registered when required env vars are present.
+
+### `slack`
+
+- Default mode: `read`
+- Operations:
+  - `messages` (`read`)
+  - `post_summary` (`write`)
+- Env:
+  - `MATTEROS_SLACK_TOKEN`
+
+### `jira`
+
+- Default mode: `read`
+- Operations:
+  - `worklogs` (`read`)
+  - `issues` (`read`)
+  - `log_time` (`write`)
+- Env:
+  - `MATTEROS_JIRA_TOKEN`
+  - `MATTEROS_JIRA_URL`
+
+### `github`
+
+- Default mode: `read`
+- Operations:
+  - `commits` (`read`)
+  - `prs` (`read`)
+- Env:
+  - `MATTEROS_GITHUB_TOKEN`
+
+### `ical`
+
+- Default mode: `read`
+- Operations:
+  - `events` (`read`)
+- No auth required (local `.ics` parsing)
+
+## Plugin connectors
+
+MatterOS can load custom connectors from:
+
+- installed Python entry points (`matteros.connectors`)
+- local plugin files/packages in `~/.matteros/plugins` (or `<home>/plugins`)
+
+Plugin connectors must provide a valid `Connector` implementation and manifest.
+
+At startup, plugins are discovered and registered unless their `connector_id` conflicts with an already-registered connector.

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -1,17 +1,32 @@
 # Policy Model
 
+MatterOS policy checks are designed to keep automation explicit and reviewable.
+
 ## Enforced rules
 
 - Playbook connector declarations must match installed connectors.
-- Step operation must exist in connector permission manifest.
+- Step operations must exist in connector permission manifests.
 - Write operations are blocked outside `apply` steps.
-- Write operations require `--approve` unless `--dry-run`.
-- Connector data is sanitized before entering shared context.
+- Write operations require `--approve` unless `--dry-run` is active.
+- Connector payloads are treated as untrusted and sanitized before shared context use.
 
 ## Safety defaults
 
-- Read-only data collection connectors.
-- Human approval gate before all external side effects.
+- Read-first collection model.
+- Human-in-the-loop approval before external side effects.
 - Structured schema validation for model-generated entries.
-- Local model provider default; remote providers require explicit opt-in.
-- Optional exact model allowlist enforcement via `MATTEROS_LLM_MODEL_ALLOWLIST`.
+- Audit events are append-only and hash-linked.
+- Local LLM provider default; remote providers are explicit opt-in.
+- Optional exact model allowlist via `MATTEROS_LLM_MODEL_ALLOWLIST`.
+
+## Web and access safeguards
+
+- Web UI requires an access token bootstrap URL or bearer token.
+- Session bootstrap tokens are generated per web process start.
+- Draft approve/reject endpoints are protected by the same web auth middleware.
+
+## Connector/plugin scope
+
+- Built-in connectors publish explicit operation modes (`read` / `write`).
+- Plugin connectors must publish valid manifests.
+- Conflicting plugin IDs are skipped instead of overriding existing connectors.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,29 +1,40 @@
-# Threat Model (MVP)
+# Threat Model (Current)
 
 ## Assets
 
 - Matter metadata and activity timelines
-- Draft billing narratives
-- Approval decisions and audit logs
+- Draft time entries and narratives
+- Approval decisions and reviewer actions
+- Audit trail integrity (SQLite + JSONL)
+- OAuth credentials and API tokens
 
 ## Trust boundaries
 
-- Local CLI runtime
-- External Microsoft Graph API
-- Local filesystem scanner
-- Optional external LLM providers
+- Local MatterOS runtime (CLI/TUI/Web/daemon)
+- Connector boundaries (Microsoft Graph, Slack, Jira, GitHub, filesystem, iCal)
+- Optional remote LLM providers
+- Plugin connector loading path (`~/.matteros/plugins` / `<home>/plugins`)
 
 ## Primary threats
 
-- Prompt injection via email/document text
-- Over-privileged connectors causing unauthorized writes
-- Tampering with run history or approvals
-- Data exfiltration via accidental provider defaults
+- Prompt injection via emails/docs/calendar text
+- Over-privileged or malicious connector/plugin behavior
+- Unauthorized writes without operator review
+- Audit trail tampering or replay gaps
+- Token leakage from mis-handled web bootstrap links
 
-## MVP mitigations
+## Mitigations in place
 
-- Untrusted connector payloads handled as data channel only
-- Connector manifests with explicit read/write operations
-- Side effects constrained to `apply` steps after approval
-- Audit events hash-chained and append-only
-- Local provider default; cloud providers are opt-in
+- Connector manifests with explicit operation permissions
+- Policy checks for connector declarations + operation validity
+- Side effects constrained to `apply` steps with approval gating
+- Audit events hash-chained and verifiable by CLI
+- Local provider default; remote providers require explicit opt-in
+- Web middleware requires token-based access
+- Plugin ID collision prevention at registry time
+
+## Residual risks
+
+- Local plugin code runs with process privileges if loaded
+- Operator error in approving low-quality suggestions
+- Secret management remains environment/config dependent


### PR DESCRIPTION
## Summary\n- rewrite README with a more engaging, operator-friendly voice\n- update install guide for Homebrew/source/pipx plus optional extras\n- refresh connector, policy, and threat docs to match current runtime behavior\n- add explicit notes for web bootstrap token flow and plugin connector discovery\n\n## Notes\n- docs-only change\n- no runtime code changes