### PR TITLE
Fix release workflow parsing for missing tap token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,6 @@ jobs:
     name: Update Homebrew Tap
     runs-on: ubuntu-latest
     needs: build_release
-    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN != '' }}
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v4
@@ -79,6 +78,11 @@ jobs:
           TAG: ${{ needs.build_release.outputs.tag }}
           SHA256: ${{ needs.build_release.outputs.sha256 }}
         run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "HOMEBREW_TAP_GITHUB_TOKEN is not set; skipping tap update."
+            exit 0
+          fi
+
           git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" tap
           mkdir -p tap/Formula
 


### PR DESCRIPTION
## Summary
- remove the invalid job-level if expression that referenced secrets
- skip Homebrew tap update inside the step when HOMEBREW_TAP_GITHUB_TOKEN is not configured

## Why
GitHub Actions was rejecting the release workflow at parse time, which prevented tag and manual release runs.
