### PR TITLE
Fix Homebrew formula install to avoid missing pip

### DIFF
--- a/packaging/homebrew/matteros.rb.tmpl
+++ b/packaging/homebrew/matteros.rb.tmpl
@@ -10,9 +10,7 @@ class Matteros < Formula
   depends_on "python@3.12"
 
   def install
-    virtualenv_create(libexec, "python3.12")
-    system libexec/"bin/pip", "install", buildpath
-    bin.install_symlink libexec/"bin/matteros"
+    virtualenv_install_with_resources(using: "python@3.12")
   end
 
   test do


### PR DESCRIPTION
## Summary
- replace direct libexec/bin/pip invocation in the Homebrew template
- use Homebrew virtualenv_install_with_resources(using: "python@3.12")

## Why
The previous formula created a venv with --without-pip and then tried to execute libexec/bin/pip, which fails during brew install.

## Validation
- updated live tap formula and verified local install succeeds.
