### PR TITLE
Fix Homebrew template to install dependencies into venv

### DIFF
--- a/packaging/homebrew/matteros.rb.tmpl
+++ b/packaging/homebrew/matteros.rb.tmpl
@@ -10,7 +10,12 @@ class Matteros < Formula
   depends_on "python@3.12"
 
   def install
-    virtualenv_install_with_resources(using: "python@3.12")
+    python = Formula["python@3.12"].opt_bin/"python3.12"
+    venv = virtualenv_create(libexec, python)
+
+    # Install project plus dependencies into the virtualenv.
+    system python, "-m", "pip", "--python=#{venv.root}/bin/python", "install", buildpath
+    bin.install_symlink venv.root/"bin/matteros"
   end
 
   test do


### PR DESCRIPTION
## Summary
- create Homebrew venv via `virtualenv_create`
- install MatterOS and its runtime dependencies by targeting the venv interpreter with pip
- link the `matteros` executable from that venv

## Why
Using `virtualenv_install_with_resources` without vendored resources omitted runtime dependencies, causing `ModuleNotFoundError` at runtime.

## Validation
- updated live tap formula with the same logic
- verified `brew reinstall danielalkurdi/matteros/matteros` succeeds
- verified `matteros --help` works after install
